### PR TITLE
Fix pylint errors

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r vader/requirements.txt
         pip install pylint
     - name: Analysing the code with pylint
       run: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Steps on how to set up a Python virtual environment and run Flask:
     cd vader
     pip install -r requirements.txt
     python installation.py
-    export FLASK_APP=vader-web.py
+    export FLASK_APP=vader_web.py
     flask run
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,5 +23,5 @@ COPY ./vader ./
 
 EXPOSE 9600/tcp
 
-CMD ["/vader/venv/bin/uwsgi", "--http", ":9600", "--mount", "/=vader-web:app"]
+CMD ["/vader/venv/bin/uwsgi", "--http", ":9600", "--mount", "/=vader_web:app"]
 

--- a/vader/installation.py
+++ b/vader/installation.py
@@ -1,6 +1,6 @@
+"""Python file to download the required NLTK modules."""
 import nltk
 nltk.download('wordnet')
 nltk.download('vader_lexicon')
 nltk.download('punkt')
 nltk.download('punkt_tab')
-

--- a/vader/vader_web.py
+++ b/vader/vader_web.py
@@ -1,3 +1,4 @@
+"""VADER sentiment analyzer webform/mini web application."""
 import json
 import nltk.data
 from flask import Flask
@@ -52,6 +53,10 @@ def score_sentences(text):
 
 
 def score_sentences_to_html(text):
+    """Score sentences using VADER and markup output with HTML and CSS
+
+    Arguments: text -- user-submitted text
+    """
     html = []
     scored_sentences = score_sentences(text)
 
@@ -61,7 +66,10 @@ def score_sentences_to_html(text):
             css_class = 'positive'
         elif item['score'] < 0:
             css_class = 'negative'
-        span = Markup('<span class="' + css_class + '">') + escape(item['sentence']) + Markup('<sup>' + format(item['score'], '.2f') + '</sup></span>')
+        span = (Markup('<span class="' + css_class + '">') +
+                escape(item['sentence']) +
+                Markup('<sup>' + format(item['score'], '.2f') +
+                '</sup></span>'))
         html.append(span)
 
     return Markup(' '.join(html))
@@ -78,6 +86,7 @@ def score_text(text):
 
 @app.route("/", methods=['GET', 'POST'])
 def index():
+    """Display the index page of the app"""
     input_text = ''
     scored_text = ''
     aggregate_score = ''
@@ -87,20 +96,19 @@ def index():
         scored_text = score_sentences_to_html(input_text)
         aggregate_score = str(score_text(input_text)['compound'])
 
-    return render_template('index.html', 
-                            input_text=input_text, 
+    return render_template('index.html',
+                            input_text=input_text,
                             scored_text=scored_text,
                             aggregate_score=aggregate_score)
 
 
 @app.route("/api")
 def score_input():
+    """Process API requests to the app"""
     text = request.args.get('text')
 
     return json.dumps(score_text_and_summary(text))
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0') 
-
-
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
Fixing the pylint errors also required renaming vader-webform (using a dash) to vader_webform (using an underscore). This required some other minor modifications to the README and the Dockerfile.